### PR TITLE
Add some improvements

### DIFF
--- a/chartmuseum2oci/README.md
+++ b/chartmuseum2oci/README.md
@@ -24,3 +24,11 @@ docker build -t goharbor/chartmuseum2oci .
 ```bash
 docker run -ti --rm goharbor/chartmuseum2oci --url $HARBOR_URL --username $HARBOR_USER --password $HARBOR_PASSWORD
 ```
+
+Note: Harbor by default has a hardcoded page size of 10, so the above command only works for the first 10 projects.
+To overcome this issue, the parameters `--page` and `--pagesize` (max. 100) can be added.
+
+Example:
+```bash
+docker run -ti --rm goharbor/chartmuseum2oci --url $HARBOR_URL --username $HARBOR_USER --password $HARBOR_PASSWORD --page 2 --pagesize 50
+```

--- a/chartmuseum2oci/README.md
+++ b/chartmuseum2oci/README.md
@@ -32,3 +32,12 @@ Example:
 ```bash
 docker run -ti --rm goharbor/chartmuseum2oci --url $HARBOR_URL --username $HARBOR_USER --password $HARBOR_PASSWORD --page 2 --pagesize 50
 ```
+
+### Destination path
+
+Using the option `--destpath` a subpath within the project can be specified, in which the charts will be pushed.
+
+In this example, the charts will be pushed into `$HARBOR_URL/$PROJECT/charts`:
+```bash
+docker run -ti --rm goharbor/chartmuseum2oci --url $HARBOR_URL --username $HARBOR_USER --password $HARBOR_PASSWORD --destpath /charts
+```

--- a/chartmuseum2oci/main.go
+++ b/chartmuseum2oci/main.go
@@ -46,6 +46,8 @@ var (
 	harborUsername string //nolint:gochecknoglobals
 	harborPassword string //nolint:gochecknoglobals
 	harborHost     string //nolint:gochecknoglobals
+	page           int64 //nolint:gochecknoglobals
+	pageSize       int64 //nolint:gochecknoglobals
 )
 
 func init() { //nolint:gochecknoinits
@@ -58,6 +60,8 @@ func initFlags() {
 	flag.StringVar(&harborURL, "url", "", "Harbor registry url")
 	flag.StringVar(&harborUsername, "username", "", "Harbor registry username")
 	flag.StringVar(&harborPassword, "password", "", "Harbor registry password")
+	flag.Int64Var(&page, "page", int64(1), "Page")
+	flag.Int64Var(&pageSize, "pagesize", int64(10), "PageSize")
 	flag.Parse()
 
 	if harborURL == "" {
@@ -90,7 +94,7 @@ func initHarborClients() {
 	harborClientV2Assist = harborClientSet.Assist()
 
 	// Check Harbor url and credentials are ok
-	params := &project.ListProjectsParams{} //nolint:exhaustruct
+	params := &project.ListProjectsParams{Page: &page, PageSize: &pageSize} //nolint:exhaustruct
 	if _, err = harborClientV2.Project.ListProjects(context.Background(), params); err != nil {
 		log.Fatal(errors.Wrap(err, "fail to contact Harbor registry, check your credentials"))
 	}
@@ -149,7 +153,7 @@ func helmLogin() error {
 func getHarborChartmuseumCharts() ([]HelmChart, error) {
 	helmCharts := make([]HelmChart, 0)
 
-	params := &project.ListProjectsParams{} //nolint:exhaustruct
+	params := &project.ListProjectsParams{Page: &page, PageSize: &pageSize} //nolint:exhaustruct
 
 	projects, err := harborClientV2.Project.ListProjects(context.Background(), params)
 	if err != nil {

--- a/chartmuseum2oci/main.go
+++ b/chartmuseum2oci/main.go
@@ -46,6 +46,7 @@ var (
 	harborUsername string //nolint:gochecknoglobals
 	harborPassword string //nolint:gochecknoglobals
 	harborHost     string //nolint:gochecknoglobals
+	destPath       string //nolint:gochecknoglobals
 	page           int64 //nolint:gochecknoglobals
 	pageSize       int64 //nolint:gochecknoglobals
 )
@@ -60,6 +61,7 @@ func initFlags() {
 	flag.StringVar(&harborURL, "url", "", "Harbor registry url")
 	flag.StringVar(&harborUsername, "username", "", "Harbor registry username")
 	flag.StringVar(&harborPassword, "password", "", "Harbor registry password")
+	flag.StringVar(&destPath, "destpath", "", "Destination subpath")
 	flag.Int64Var(&page, "page", int64(1), "Page")
 	flag.Int64Var(&pageSize, "pagesize", int64(10), "PageSize")
 	flag.Parse()
@@ -260,7 +262,7 @@ func pullChartFromChartmuseum(helmChart HelmChart) error {
 }
 
 func pushChartToOCI(helmChart HelmChart) error {
-	repoURL := fmt.Sprintf("oci://%s/%s", harborHost, helmChart.Project)
+	repoURL := fmt.Sprintf("oci://%s/%s%s", harborHost, helmChart.Project, destPath)
 	cmd := exec.Command(helmBinaryPath, "push", helmChart.ChartFileName(), repoURL) //nolint:gosec
 
 	var stdErr bytes.Buffer


### PR DESCRIPTION
1. Add more verbose logging information in case a migration fails (which chart failed in which project)

2. Harbor has a hardcoded pagesize of 10, so this script only worked for the first 10 projects. We added pagination parameters, which allow to steer, which projects to run (ex. not all at the same time, for large Harbor installations).

3. Added a parameter called destpath, which allows to specify if charts should be pushed into a separate destination path. This is useful, because often images and charts have the same name and version, so charts can be pushed into a /charts subpath within the project.