### PR TITLE
add destproject option to push to different project

### DIFF
--- a/chartmuseum2oci/main.go
+++ b/chartmuseum2oci/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"cmp"
 	"context"
 	"flag"
 	"fmt"
@@ -277,8 +276,14 @@ func pullChartFromChartmuseum(helmChart HelmChart) error {
 }
 
 func pushChartToOCI(helmChart HelmChart) error {
-	var project = cmp.Or(destProject, helmChart.Project)
-	repoURL := fmt.Sprintf("oci://%s/%s%s", harborHost, project, destPath)
+	var harborProject string
+	if destProject != "" {
+		harborProject = destProject
+	} else {
+		harborProject = helmChart.Project
+	}
+
+	repoURL := fmt.Sprintf("oci://%s/%s%s", harborHost, harborProject, destPath)
 	cmd := exec.Command(helmBinaryPath, "push", helmChart.ChartFileName(), repoURL) //nolint:gosec
 
 	var stdErr bytes.Buffer

--- a/chartmuseum2oci/main.go
+++ b/chartmuseum2oci/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"flag"
 	"fmt"
@@ -49,6 +50,7 @@ var (
 	harborUsername    string                //nolint:gochecknoglobals
 	harborPassword    string                //nolint:gochecknoglobals
 	harborHost        string                //nolint:gochecknoglobals
+	destProject       string                //nolint:gochecknoglobals
 	destPath          string                //nolint:gochecknoglobals
 	projectsToMigrate ProjectsToMigrateList //nolint:gochecknoglobals
 )
@@ -63,6 +65,7 @@ func initFlags() {
 	flag.StringVar(&harborURL, "url", "", "Harbor registry url")
 	flag.StringVar(&harborUsername, "username", "", "Harbor registry username")
 	flag.StringVar(&harborPassword, "password", "", "Harbor registry password")
+	flag.StringVar(&destProject, "destproject", "", "Destination project")
 	flag.StringVar(&destPath, "destpath", "", "Destination subpath")
 	flag.Var(&projectsToMigrate, "project", "Name of the project(s) to migrate")
 	flag.Parse()
@@ -274,7 +277,8 @@ func pullChartFromChartmuseum(helmChart HelmChart) error {
 }
 
 func pushChartToOCI(helmChart HelmChart) error {
-	repoURL := fmt.Sprintf("oci://%s/%s%s", harborHost, helmChart.Project, destPath)
+	var project = cmp.Or(destProject, helmChart.Project)
+	repoURL := fmt.Sprintf("oci://%s/%s%s", harborHost, project, destPath)
 	cmd := exec.Command(helmBinaryPath, "push", helmChart.ChartFileName(), repoURL) //nolint:gosec
 
 	var stdErr bytes.Buffer


### PR DESCRIPTION
Rancher does not allow project to contains both images and charts.

So we need an option to migrate chartmuseum charts to an other project.

We add destproject option for this