### PR TITLE
support insecure harbor  migration.

### DIFF
--- a/chartmuseum2oci/Dockerfile
+++ b/chartmuseum2oci/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder
+FROM golang:1.20 AS builder
 
 WORKDIR /root/src
 
@@ -17,9 +17,21 @@ RUN go build -a \
 
 FROM alpine AS helm
 
-ARG HELM_VERSION="v3.12.1"
-RUN wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - \
-    | tar -xzO linux-amd64/helm > /bin/helm && \
+ARG HELM_VERSION="v3.19.0"
+ARG TARGETARCH
+
+# Set default architecture if not provided
+RUN if [ -z "$TARGETARCH" ]; then \
+        ARCH=$(uname -m); \
+        case $ARCH in \
+            x86_64) TARGETARCH=amd64 ;; \
+            aarch64|arm64) TARGETARCH=arm64 ;; \
+            armv7l) TARGETARCH=arm ;; \
+            *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+        esac; \
+    fi
+    wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz -O - \
+    | tar -xzO linux-${TARGETARCH}/helm > /bin/helm && \
     chmod +x /bin/helm
 
 ############################

--- a/chartmuseum2oci/README.md
+++ b/chartmuseum2oci/README.md
@@ -41,3 +41,26 @@ In this example, the charts will be pushed into `$HARBOR_URL/$PROJECT/charts`:
 ```bash
 docker run -ti --rm goharbor/chartmuseum2oci --url $HARBOR_URL --username $HARBOR_USER --password $HARBOR_PASSWORD --destpath /charts
 ```
+
+### Security options
+
+#### Insecure TLS verification
+
+Using the option `--insecure` to skip TLS verification for helm operations. This is useful when working with self-signed certificates or internal registries.
+
+```bash
+docker run -ti --rm goharbor/chartmuseum2oci --url $HARBOR_URL --username $HARBOR_USER --password $HARBOR_PASSWORD --insecure
+```
+
+#### Plain HTTP
+
+Using the option `--plain-http` to use plain HTTP instead of HTTPS for helm operations. This should only be used in secure internal networks.
+
+```bash
+docker run -ti --rm goharbor/chartmuseum2oci --url $HARBOR_URL --username $HARBOR_USER --password $HARBOR_PASSWORD --plain-http
+```
+
+Both security options can be combined:
+```bash
+docker run -ti --rm goharbor/chartmuseum2oci --url $HARBOR_URL --username $HARBOR_USER --password $HARBOR_PASSWORD --insecure --plain-http
+```

--- a/chartmuseum2oci/main.go
+++ b/chartmuseum2oci/main.go
@@ -51,6 +51,9 @@ var (
 	harborHost        string                //nolint:gochecknoglobals
 	destPath          string                //nolint:gochecknoglobals
 	projectsToMigrate ProjectsToMigrateList //nolint:gochecknoglobals
+
+	insecure  bool //nolint:gochecknoglobals
+	plainHttp bool //nolint:gochecknoglobals
 )
 
 func init() { //nolint:gochecknoinits
@@ -65,6 +68,8 @@ func initFlags() {
 	flag.StringVar(&harborPassword, "password", "", "Harbor registry password")
 	flag.StringVar(&destPath, "destpath", "", "Destination subpath")
 	flag.Var(&projectsToMigrate, "project", "Name of the project(s) to migrate")
+	flag.BoolVar(&insecure, "insecure", false, "Skip TLS verification for helm operations")
+	flag.BoolVar(&plainHttp, "plain-http", false, "Use plain HTTP for helm operations")
 	flag.Parse()
 
 	if harborURL == "" {
@@ -140,8 +145,19 @@ func main() {
 	log.Printf("%d Helm charts successfully migrated from Chartmuseum to OCI", len(helmChartsToMigrate)-errorCount)
 }
 
+// helmLogin performs helm registry login with optional extra arguments
 func helmLogin() error {
-	cmd := exec.Command(helmBinaryPath, "registry", "login", "--username", harborUsername, "--password", harborPassword, harborURL) //nolint:lll
+	params := []string{"registry", "login", "--username", harborUsername, "--password", harborPassword, harborURL}
+	// Add extra arguments if provided
+	if insecure {
+		params = append(params, "--insecure")
+	}
+
+	if plainHttp {
+		params = append(params, "--plain-http")
+	}
+
+	cmd := exec.Command(helmBinaryPath, params...) //nolint:gosec
 
 	var stdErr bytes.Buffer
 	cmd.Stderr = &stdErr
@@ -275,7 +291,16 @@ func pullChartFromChartmuseum(helmChart HelmChart) error {
 
 func pushChartToOCI(helmChart HelmChart) error {
 	repoURL := fmt.Sprintf("oci://%s/%s%s", harborHost, helmChart.Project, destPath)
-	cmd := exec.Command(helmBinaryPath, "push", helmChart.ChartFileName(), repoURL) //nolint:gosec
+	params := []string{"push", helmChart.ChartFileName(), repoURL}
+	if insecure {
+		params = append(params, "--insecure-skip-tls-verify")
+	}
+
+	if plainHttp {
+		params = append(params, "--plain-http")
+	}
+
+	cmd := exec.Command(helmBinaryPath, params...) //nolint:gosec
 
 	var stdErr bytes.Buffer
 	cmd.Stderr = &stdErr


### PR DESCRIPTION
When the harbor to be migrated is HTTP or using a self-signed certificate, there are no parameters that can be passed to helm. 

Add parameter support for this kind of migration.