### PR TITLE
Missing 'RUN' to invoke wget.

### DIFF
--- a/chartmuseum2oci/Dockerfile
+++ b/chartmuseum2oci/Dockerfile
@@ -30,7 +30,7 @@ RUN if [ -z "$TARGETARCH" ]; then \
             *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
         esac; \
     fi
-    wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz -O - \
+RUN wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz -O - \
     | tar -xzO linux-${TARGETARCH}/helm > /bin/helm && \
     chmod +x /bin/helm
 


### PR DESCRIPTION
Had the below error, when trying to build the image:

`2025/09/25 13:36:03 http2: server: error reading preface from client //./pipe/docker_engine: file has already been closed
[+] Building 0.0s (1/1) FINISHED                                                                                                             docker:default
 => [internal] load build definition from Dockerfile                                                                                                   0.0s
 => => transferring dockerfile: 1.16kB                                                                                                                 0.0s
Dockerfile:33
--------------------
  32 |         fi
  33 | >>>     wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz -O - \
  34 | >>>     | tar -xzO linux-${TARGETARCH}/helm > /bin/helm && \
  35 | >>>     chmod +x /bin/helm
  36 |
--------------------
ERROR: failed to solve: dockerfile parse error on line 33: unknown instruction: wget`