### PR TITLE
Fix/golangci lint and bump deprecated actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Cache Go modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -47,11 +47,10 @@ jobs:
           go test -v ./...
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v1.64
           working-directory: chartmuseum2oci
-          args: --timeout=5m
 
   build:
     name: Build
@@ -64,14 +63,10 @@ jobs:
             goos: linux
             goarch: amd64
             artifact_name: chartmuseum2oci-linux-amd64
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             goos: linux
             goarch: arm64
             artifact_name: chartmuseum2oci-linux-arm64
-          - os: macos-latest
-            goos: darwin
-            goarch: amd64
-            artifact_name: chartmuseum2oci-darwin-amd64
           - os: macos-latest
             goos: darwin
             goarch: arm64
@@ -82,7 +77,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -110,7 +105,7 @@ jobs:
           ./${{ matrix.artifact_name }} --version
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
           path: chartmuseum2oci/${{ matrix.artifact_name }}

--- a/chartmuseum2oci/.golangci.yml
+++ b/chartmuseum2oci/.golangci.yml
@@ -1,19 +1,25 @@
 run:
-  deadline: 10m
-  modules-download-mode: vendor
+  timeout: 10m
 
 linters:
-  enable-all: true
-  disable:
-    - deadcode # Deprecated: replaced by unused
-    - exhaustivestruct # Deprecated: https://github.com/golangci/golangci-lint/issues/2923
-    - golint # Deprecated: replaced by revive
-    - ifshort # Deprecated
-    - interfacer # Deprecated
-    - maligned # Deprecated: replaced by govet 'fieldalignment'
-    - nosnakecase # Deprecated: replaced by revive(var-naming)
-    - scopelint # Deprecated: replaced by revive
-    - structcheck # Deprecated: replaced by unused
-    - tagliatelle
-    - testpackage
-    - varcheck # Deprecated: replaced by unused
+  disable-all: true
+  enable:
+    - bodyclose
+    - errcheck
+    - errorlint
+    - exhaustive
+    - goconst
+    - gocritic
+    - gocyclo
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace

--- a/chartmuseum2oci/main.go
+++ b/chartmuseum2oci/main.go
@@ -57,7 +57,7 @@ var (
 	projectsToMigrate ProjectsToMigrateList //nolint:gochecknoglobals
 
 	insecure    bool //nolint:gochecknoglobals
-	plainHttp   bool //nolint:gochecknoglobals
+	plainHTTP   bool //nolint:gochecknoglobals
 	showVersion bool //nolint:gochecknoglobals
 
 	// Version information set during build
@@ -79,7 +79,7 @@ func initFlags() {
 	flag.StringVar(&destPath, "destpath", "", "Destination subpath")
 	flag.Var(&projectsToMigrate, "project", "Name of the project(s) to migrate")
 	flag.BoolVar(&insecure, "insecure", false, "Skip TLS verification for helm operations")
-	flag.BoolVar(&plainHttp, "plain-http", false, "Use plain HTTP for helm operations")
+	flag.BoolVar(&plainHTTP, "plain-http", false, "Use plain HTTP for helm operations")
 	flag.BoolVar(&showVersion, "version", false, "Show version information")
 	flag.Parse()
 
@@ -234,7 +234,7 @@ func helmLogin() error {
 		params = append(params, "--insecure")
 	}
 
-	if plainHttp {
+	if plainHTTP {
 		params = append(params, "--plain-http")
 	}
 
@@ -377,7 +377,7 @@ func pushChartToOCI(helmChart HelmChart) error {
 		params = append(params, "--insecure-skip-tls-verify")
 	}
 
-	if plainHttp {
+	if plainHTTP {
 		params = append(params, "--plain-http")
 	}
 


### PR DESCRIPTION
# fix lint
There are ci lint errors.
The linters enable-all, this is too over, change it to a white list.

# bump actions
Bumped all deprecated actions:
- actions/setup-go v4 → v5
- actions/cache v3 → v4
- actions/upload-artifact v3 → v4

# remove unsupported runner
Because action result (from https://github.com/goharbor/chartmuseum-migration-tools/actions/runs/23429721399)
'The configuration 'macos-13-us-default' is not supported'

Remove runner:
darwin/amd64